### PR TITLE
Always call drawValue

### DIFF
--- a/Charts/Classes/Renderers/BarChartRenderer.swift
+++ b/Charts/Classes/Renderers/BarChartRenderer.swift
@@ -455,12 +455,13 @@ public class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                             {
                                 break
                             }
-                            
-                            if !viewPortHandler.isInBoundsY(rect.origin.y)
-                                || !viewPortHandler.isInBoundsLeft(x)
-                            {
-                                continue
-                            }
+//                             
+//                             Always redraw
+//                             if !viewPortHandler.isInBoundsY(rect.origin.y)
+//                                 || !viewPortHandler.isInBoundsLeft(x)
+//                             {
+//                                 continue
+//                             }
                             
                             drawValue(
                                 context: context,


### PR DESCRIPTION
Calling formatter.stringForValue() is needed as some labels are not showing